### PR TITLE
Various fixes

### DIFF
--- a/matrix_benchmarking/matrix.py
+++ b/matrix_benchmarking/matrix.py
@@ -137,7 +137,7 @@ EXEC_DIR="$(realpath "$2")"
                     if "=" not in kv:
                         raise ValueError(f"Invalid 'extra' setting: '{extra}' ('{kv}' has no '=')")
                     k, v = kv.split("=")
-                    settings[k] = v
+                    settings[k.strip()] = v.strip()
 
             key = common.Matrix.settings_to_key(settings)
 

--- a/matrix_benchmarking/store/prom_db.py
+++ b/matrix_benchmarking/store/prom_db.py
@@ -101,7 +101,7 @@ def extract_metrics(prometheus_tgz, metrics, dirname):
         metric_file = metrics_base_dir / f"{metric_filename}.json"
         if not metric_file.exists():
             missing_metrics.append([metric_name, metric_query, metric_file])
-            logging.info(f"Metric {metric_name} missing")
+            logging.info(f"No cache available for metric '{metric_name}'")
             continue
 
         metric_results[metric_name] = _parse_metric_values_from_file(metric_file)

--- a/matrix_benchmarking/store/simple.py
+++ b/matrix_benchmarking/store/simple.py
@@ -143,5 +143,5 @@ def parse_data(results_dir=None):
         this_dir = pathlib.Path(_this_dir)
 
         relative = this_dir.relative_to(results_dir)
-        expe_name = relative.parents[0].name if relative.parents and relative.parents[0].name else "expe"
+        expe_name = relative.parents[-2].name if relative.parents and relative.parents[0].name else "expe"
         _parse_directory(results_dir, expe_name, this_dir)

--- a/matrix_benchmarking/workloads/oauth-proxy_scale_test
+++ b/matrix_benchmarking/workloads/oauth-proxy_scale_test
@@ -1,0 +1,1 @@
+/home/kevin/openshift/ci-artifacts/subprojects/oauth-proxy_scale_test


### PR DESCRIPTION
* `matrix_benchmarking/matrix.py: allow spaces in the benchmark file 'extra' settings`


---

* `matrix_benchmarking/store/simple.py: properly parse the expe_name`


---

* `matrix_benchmarking/store/prom_db.py: clarify the message when 'No cache available for metric xxx'`


---

* `matrix_benchmarking/workloads/oauth-proxy_scale_test: new workload link`


---