### PR TITLE
Pin pydantic at the latest version of 1.10.x

### DIFF
--- a/matrix_benchmarking/models.py
+++ b/matrix_benchmarking/models.py
@@ -4,7 +4,7 @@ from typing import List, Tuple, Dict, Union, Optional
 import datetime as dt
 from enum import Enum
 
-from pydantic import BaseModel, ConstrainedStr, constr, Extra
+from pydantic.v1 import BaseModel, ConstrainedStr, constr, Extra
 import pydantic
 
 SEMVER_REGEX="(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
@@ -15,7 +15,7 @@ class ExclusiveModel(BaseModel):
     class Config:
         extra = Extra.forbid
 
-class AllOptional(pydantic.main.ModelMetaclass):
+class AllOptional(pydantic.v1.main.ModelMetaclass):
     def __new__(self, name, bases, namespaces, **kwargs):
         annotations = namespaces.get('__annotations__', {})
         for base in bases:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pyyaml
 BeautifulSoup4==4.11.*
 python-keycloak
 prometheus_api_client
-pydantic
+pydantic==1.10.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pyyaml
 BeautifulSoup4==4.11.*
 python-keycloak
 prometheus_api_client
-pydantic==1.10.*
+pydantic


### PR DESCRIPTION
Pydantic released their version 2, which breaks the pipeline.  
```
Traceback (most recent call last):
  File "/usr/lib64/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/opt/ci-artifacts/src/subprojects/matrix-benchmarking/matrix_benchmarking/main.py", line 12, in <module>
    import matrix_benchmarking.visualize
  File "/opt/ci-artifacts/src/subprojects/matrix-benchmarking/matrix_benchmarking/visualize.py", line 4, in <module>
    import matrix_benchmarking.matrix
  File "/opt/ci-artifacts/src/subprojects/matrix-benchmarking/matrix_benchmarking/matrix.py", line 9, in <module>
    import matrix_benchmarking.store as store
  File "/opt/ci-artifacts/src/subprojects/matrix-benchmarking/matrix_benchmarking/store/__init__.py", line 10, in <module>
    import matrix_benchmarking.models as models
  File "/opt/ci-artifacts/src/subprojects/matrix-benchmarking/matrix_benchmarking/models.py", line 7, in <module>
    from pydantic import BaseModel, ConstrainedStr, constr, Extra
  File "/opt/venv/lib/python3.9/site-packages/pydantic/__init__.py", line 206, in __getattr__
    return _getattr_migration(attr_name)
  File "/opt/venv/lib/python3.9/site-packages/pydantic/_migration.py", line 285, in wrapper
    raise PydanticImportError(f'`{import_path}` has been removed in V2.')
pydantic.errors.PydanticImportError: `pydantic:ConstrainedStr` has been removed in V2.

For further information visit https://errors.pydantic.dev/2.0/u/import-error
```