### PR TITLE
Improve the handling of matrices with different set of settings

### DIFF
--- a/matrix_benchmarking/analyze_lts.py
+++ b/matrix_benchmarking/analyze_lts.py
@@ -55,6 +55,7 @@ Args:
         logging.info(f"Loading results ... ")
 
         workload_store.parse_data()
+        common.Matrix.uniformize_settings_keys()
         common.Matrix.print_settings_to_log()
         logging.info(f"Loading results ... done. Found {len(common.Matrix.processed_map)} results.")
         logging.info("")

--- a/matrix_benchmarking/benchmark.py
+++ b/matrix_benchmarking/benchmark.py
@@ -86,6 +86,7 @@ Args:
         logging.info(f"Loading previous results ... ")
         workload_store.parse_data()
         logging.info(f"Loading previous results: done, found {len(common.Matrix.processed_map)} results")
+        common.Matrix.uniformize_settings_keys()
 
         if dry:
             logging.info("#")

--- a/matrix_benchmarking/common.py
+++ b/matrix_benchmarking/common.py
@@ -48,6 +48,20 @@ class MatrixEntry(types.SimpleNamespace):
         return hasattr(self.results, 'check_thresholds') and self.results.check_thresholds
 
 
+class MatrixKey(dict):
+    def __init__(self, settings):
+        self.settings = settings
+
+    def __str__(self):
+        return "|".join(f"{k}={self.settings[k]}" for k in sorted(self.settings) if k != "stats")
+
+    def __repr__(self):
+        return str(self)
+
+    def __hash__(self):
+        return hash(str(self))
+
+
 class MatrixDefinition():
     def __init__(self, is_lts=False):
         self.settings = defaultdict(set)
@@ -56,7 +70,7 @@ class MatrixDefinition():
         self.is_lts = is_lts
 
     def settings_to_key(self, settings):
-        return "|".join(f"{k}={settings[k]}" for k in sorted(settings) if k != "stats")
+        return MatrixKey(settings)
 
     def all_records(self, settings=None, setting_lists=None) -> Iterator[MatrixEntry]:
         if settings is None and setting_lists is None:

--- a/matrix_benchmarking/parse.py
+++ b/matrix_benchmarking/parse.py
@@ -93,6 +93,7 @@ Args:
             workload_store.parse_data()
 
         logging.info(f"Loading results: done, found {len(common.Matrix.processed_map)} results")
+        common.Matrix.uniformize_settings_keys()
 
         if kwargs["clean"]:
             if not kwargs["run"]:

--- a/matrix_benchmarking/upload_lts.py
+++ b/matrix_benchmarking/upload_lts.py
@@ -69,6 +69,7 @@ Args:
         logging.info(f"Loading results: done, found {len(common.Matrix.processed_map)} results")
 
         common.Matrix.print_settings_to_log()
+        common.Matrix.uniformize_settings_keys()
 
         client = download_lts.connect_opensearch_client(kwargs) \
             if not kwargs.get("dry_run") else None

--- a/matrix_benchmarking/visualize.py
+++ b/matrix_benchmarking/visualize.py
@@ -63,6 +63,9 @@ Args:
         if not common.Matrix.processed_map:
             logging.error("Not result found, exiting.")
             return 1
+
+        common.Matrix.uniformize_settings_keys()
+
         common.Matrix.print_settings_to_log()
 
         if kwargs.get("lts_results_dirname"):


### PR DESCRIPTION
Before this PR, the `all_records` would miss the entries with missing/undefined settings.
This PR uniformizes the list of settings, by setting to `None` any undefined setting.